### PR TITLE
[py36,py37] Added workflows to build on multiple os and platforms. Other changes, see details.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -68,7 +68,7 @@ jobs:
   pre-commit:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest"]   # skip pre-commit step on "windows-latest" because of some platform-specific hooks
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]  # skip bandit step on python <3.8 because of platform-specific dependency.
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
   doc8:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10"]  # skip bandit step on python <3.8 because of platform-specific dependency.
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]  # skip bandit step on python <3.8 because of platform-specific dependency.
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/tests/datamodules/test_cifar.py
+++ b/tests/datamodules/test_cifar.py
@@ -4,6 +4,7 @@
 """Tests for CIFAR PyTorch LightningDataModule module in `torchfl` package."""
 import pytest
 from torchfl.datamodules.cifar import CIFARDataModule
+from torchfl.datamodules.cifar import SUPPORTED_DATASETS_TYPE
 from collections import Counter
 
 
@@ -14,7 +15,7 @@ def cifar10_data_module():
     Returns:
         CIFARDataModule: PyTorch LightningDataModule for CIFAR10.
     """
-    return CIFARDataModule(dataset_name="cifar10")
+    return CIFARDataModule(dataset_name=SUPPORTED_DATASETS_TYPE.CIFAR10)
 
 
 @pytest.fixture
@@ -24,7 +25,7 @@ def cifar100_data_module():
     Returns:
         CIFARDataModule: PyTorch LightningDataModule for CIFAR100.
     """
-    return CIFARDataModule(dataset_name="cifar100")
+    return CIFARDataModule(dataset_name=SUPPORTED_DATASETS_TYPE.CIFAR100)
 
 
 def test_cifar10_train_val_split(cifar10_data_module):

--- a/tests/datamodules/test_emnist.py
+++ b/tests/datamodules/test_emnist.py
@@ -4,6 +4,7 @@
 """Tests for EMNIST PyTorch LightningDataModule module in `torchfl` package."""
 import pytest
 from torchfl.datamodules.emnist import EMNISTDataModule
+from torchfl.datamodules.emnist import SUPPORTED_DATASETS_TYPE
 from collections import Counter
 
 
@@ -14,7 +15,7 @@ def emnist_balanced_data_module():
     Returns:
         EMNISTDataModule: PyTorch LightningDataModule for EMNIST
     """
-    return EMNISTDataModule(dataset_name="balanced")
+    return EMNISTDataModule(dataset_name=SUPPORTED_DATASETS_TYPE.BALANCED)
 
 
 @pytest.fixture
@@ -24,7 +25,7 @@ def emnist_byclass_data_module():
     Returns:
         EMNISTDataModule: PyTorch LightningDataModule for EMNIST
     """
-    return EMNISTDataModule(dataset_name="byclass")
+    return EMNISTDataModule(dataset_name=SUPPORTED_DATASETS_TYPE.BYCLASS)
 
 
 @pytest.fixture
@@ -34,7 +35,7 @@ def emnist_bymerge_data_module():
     Returns:
         EMNISTDataModule: PyTorch LightningDataModule for EMNIST.
     """
-    return EMNISTDataModule(dataset_name="bymerge")
+    return EMNISTDataModule(dataset_name=SUPPORTED_DATASETS_TYPE.BYMERGE)
 
 
 @pytest.fixture
@@ -44,7 +45,7 @@ def emnist_digits_data_module():
     Returns:
         EMNISTDataModule: PyTorch LightningDataModule for EMNIST.
     """
-    return EMNISTDataModule(dataset_name="digits")
+    return EMNISTDataModule(dataset_name=SUPPORTED_DATASETS_TYPE.DIGITS)
 
 
 @pytest.fixture
@@ -54,7 +55,7 @@ def emnist_letters_data_module():
     Returns:
         EMNISTDataModule: PyTorch LightningDataModule for EMNIST.
     """
-    return EMNISTDataModule(dataset_name="letters")
+    return EMNISTDataModule(dataset_name=SUPPORTED_DATASETS_TYPE.LETTERS)
 
 
 @pytest.fixture
@@ -64,7 +65,7 @@ def emnist_mnist_data_module():
     Returns:
         EMNISTDataModule: PyTorch LightningDataModule for EMNIST.
     """
-    return EMNISTDataModule(dataset_name="mnist")
+    return EMNISTDataModule(dataset_name=SUPPORTED_DATASETS_TYPE.MNIST)
 
 
 ############

--- a/tests/models/cifar/cifar10/test_alexnet.py
+++ b/tests/models/cifar/cifar10/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar10.alexnet import AlexNet
 import torch
 
@@ -29,7 +30,7 @@ def cifar10_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar10/test_densenet.py
+++ b/tests/models/cifar/cifar10/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar10.densenet import (
     DenseNet121,
     DenseNet161,
@@ -34,7 +35,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar10/test_lenet.py
+++ b/tests/models/cifar/cifar10/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar10.lenet import LeNet
 import torch
 
@@ -29,7 +30,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar10/test_mobilenet.py
+++ b/tests/models/cifar/cifar10/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar10.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -33,7 +34,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar10/test_resnet.py
+++ b/tests/models/cifar/cifar10/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar10.resnet import (
     ResNet18,
     ResNet34,
@@ -39,7 +40,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar10/test_shufflenetv2.py
+++ b/tests/models/cifar/cifar10/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar10.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -34,7 +35,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar10/test_squeezenet.py
+++ b/tests/models/cifar/cifar10/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar10.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -29,7 +30,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar10/test_vgg.py
+++ b/tests/models/cifar/cifar10/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar10.vgg import (
     VGG11,
     VGG11_BN,
@@ -38,7 +39,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar100/test_alexnet.py
+++ b/tests/models/cifar/cifar100/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar100.alexnet import AlexNet
 import torch
 
@@ -29,7 +30,7 @@ def cifar100_loader():
     """
     global data_transforms
     return datasets.CIFAR100(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar100/test_densenet.py
+++ b/tests/models/cifar/cifar100/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar100.densenet import (
     DenseNet121,
     DenseNet161,
@@ -34,7 +35,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR100(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar100/test_lenet.py
+++ b/tests/models/cifar/cifar100/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar100.lenet import LeNet
 import torch
 
@@ -29,7 +30,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR100(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar100/test_mobilenet.py
+++ b/tests/models/cifar/cifar100/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar100.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -33,7 +34,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR10(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar100/test_resnet.py
+++ b/tests/models/cifar/cifar100/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar100.resnet import (
     ResNet18,
     ResNet34,
@@ -39,7 +40,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR100(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar100/test_shufflenetv2.py
+++ b/tests/models/cifar/cifar100/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar100.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -34,7 +35,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR100(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar100/test_squeezenet.py
+++ b/tests/models/cifar/cifar100/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar100.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -29,7 +30,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR100(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/cifar/cifar100/test_vgg.py
+++ b/tests/models/cifar/cifar100/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.cifar.cifar100.vgg import (
     VGG11,
     VGG11_BN,
@@ -38,7 +39,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.CIFAR100(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train"],

--- a/tests/models/emnist/balanced/test_alexnet.py
+++ b/tests/models/emnist/balanced/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.alexnet import AlexNet
 import torch
 
@@ -38,7 +39,7 @@ def emnist_balanced_single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="balanced",
         download=True,
@@ -55,7 +56,7 @@ def emnist_balanced_3_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="balanced",
         download=True,

--- a/tests/models/emnist/balanced/test_densenet.py
+++ b/tests/models/emnist/balanced/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.densenet import (
     DenseNet121,
     DenseNet161,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",

--- a/tests/models/emnist/balanced/test_lenet.py
+++ b/tests/models/emnist/balanced/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.lenet import LeNet
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="balanced",
         download=True,
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="balanced",
         download=True,

--- a/tests/models/emnist/balanced/test_mlp.py
+++ b/tests/models/emnist/balanced/test_mlp.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.mlp import MLP
 import torch
 
@@ -35,7 +36,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",
@@ -52,7 +53,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",

--- a/tests/models/emnist/balanced/test_mobilenet.py
+++ b/tests/models/emnist/balanced/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -42,7 +43,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",
@@ -59,7 +60,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",

--- a/tests/models/emnist/balanced/test_resnet.py
+++ b/tests/models/emnist/balanced/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.resnet import (
     ResNet18,
     ResNet34,
@@ -48,7 +49,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",
@@ -65,7 +66,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",

--- a/tests/models/emnist/balanced/test_shufflenetv2.py
+++ b/tests/models/emnist/balanced/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",

--- a/tests/models/emnist/balanced/test_squeezenet.py
+++ b/tests/models/emnist/balanced/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",

--- a/tests/models/emnist/balanced/test_vgg.py
+++ b/tests/models/emnist/balanced/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.balanced.vgg import (
     VGG11,
     VGG11_BN,
@@ -47,7 +48,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",
@@ -64,7 +65,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="balanced",

--- a/tests/models/emnist/byclass/test_alexnet.py
+++ b/tests/models/emnist/byclass/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.alexnet import AlexNet
 import torch
 
@@ -38,7 +39,7 @@ def emnist_single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",
@@ -55,7 +56,7 @@ def emnist_3_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="byclass",
         download=True,

--- a/tests/models/emnist/byclass/test_densenet.py
+++ b/tests/models/emnist/byclass/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.densenet import (
     DenseNet121,
     DenseNet161,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",

--- a/tests/models/emnist/byclass/test_lenet.py
+++ b/tests/models/emnist/byclass/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.lenet import LeNet
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="byclass",
         download=True,
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="byclass",
         download=True,

--- a/tests/models/emnist/byclass/test_mlp.py
+++ b/tests/models/emnist/byclass/test_mlp.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.mlp import MLP
 import torch
 
@@ -35,7 +36,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",
@@ -52,7 +53,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",

--- a/tests/models/emnist/byclass/test_mobilenet.py
+++ b/tests/models/emnist/byclass/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -42,7 +43,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",
@@ -59,7 +60,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",

--- a/tests/models/emnist/byclass/test_resnet.py
+++ b/tests/models/emnist/byclass/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.resnet import (
     ResNet18,
     ResNet34,
@@ -48,7 +49,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",
@@ -65,7 +66,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",

--- a/tests/models/emnist/byclass/test_shufflenetv2.py
+++ b/tests/models/emnist/byclass/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",

--- a/tests/models/emnist/byclass/test_squeezenet.py
+++ b/tests/models/emnist/byclass/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",

--- a/tests/models/emnist/byclass/test_vgg.py
+++ b/tests/models/emnist/byclass/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.byclass.vgg import (
     VGG11,
     VGG11_BN,
@@ -47,7 +48,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",
@@ -64,7 +65,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="byclass",

--- a/tests/models/emnist/bymerge/test_alexnet.py
+++ b/tests/models/emnist/bymerge/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.alexnet import AlexNet
 import torch
 
@@ -38,7 +39,7 @@ def emnist_single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",
@@ -55,7 +56,7 @@ def emnist_3_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="byclass",
         download=True,

--- a/tests/models/emnist/bymerge/test_densenet.py
+++ b/tests/models/emnist/bymerge/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.densenet import (
     DenseNet121,
     DenseNet161,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",

--- a/tests/models/emnist/bymerge/test_lenet.py
+++ b/tests/models/emnist/bymerge/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.lenet import LeNet
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="bymerge",
         download=True,
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="bymerge",
         download=True,

--- a/tests/models/emnist/bymerge/test_mlp.py
+++ b/tests/models/emnist/bymerge/test_mlp.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.mlp import MLP
 import torch
 
@@ -35,7 +36,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",
@@ -52,7 +53,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",

--- a/tests/models/emnist/bymerge/test_mobilenet.py
+++ b/tests/models/emnist/bymerge/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -42,7 +43,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",
@@ -59,7 +60,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",

--- a/tests/models/emnist/bymerge/test_resnet.py
+++ b/tests/models/emnist/bymerge/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.resnet import (
     ResNet18,
     ResNet34,
@@ -48,7 +49,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",
@@ -65,7 +66,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",

--- a/tests/models/emnist/bymerge/test_shufflenetv2.py
+++ b/tests/models/emnist/bymerge/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",

--- a/tests/models/emnist/bymerge/test_squeezenet.py
+++ b/tests/models/emnist/bymerge/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",

--- a/tests/models/emnist/bymerge/test_vgg.py
+++ b/tests/models/emnist/bymerge/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.bymerge.vgg import (
     VGG11,
     VGG11_BN,
@@ -47,7 +48,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",
@@ -64,7 +65,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="bymerge",

--- a/tests/models/emnist/digits/test_alexnet.py
+++ b/tests/models/emnist/digits/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.alexnet import AlexNet
 import torch
 
@@ -38,7 +39,7 @@ def emnist_single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",
@@ -55,7 +56,7 @@ def emnist_3_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="byclass",
         download=True,

--- a/tests/models/emnist/digits/test_densenet.py
+++ b/tests/models/emnist/digits/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.densenet import (
     DenseNet121,
     DenseNet161,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",

--- a/tests/models/emnist/digits/test_lenet.py
+++ b/tests/models/emnist/digits/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.lenet import LeNet
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="digits",
         download=True,
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="digits",
         download=True,

--- a/tests/models/emnist/digits/test_mlp.py
+++ b/tests/models/emnist/digits/test_mlp.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.mlp import MLP
 import torch
 
@@ -35,7 +36,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",
@@ -52,7 +53,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",

--- a/tests/models/emnist/digits/test_mobilenet.py
+++ b/tests/models/emnist/digits/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -42,7 +43,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",
@@ -59,7 +60,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",

--- a/tests/models/emnist/digits/test_resnet.py
+++ b/tests/models/emnist/digits/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.resnet import (
     ResNet18,
     ResNet34,
@@ -48,7 +49,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",
@@ -65,7 +66,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",

--- a/tests/models/emnist/digits/test_shufflenetv2.py
+++ b/tests/models/emnist/digits/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",

--- a/tests/models/emnist/digits/test_squeezenet.py
+++ b/tests/models/emnist/digits/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",

--- a/tests/models/emnist/digits/test_vgg.py
+++ b/tests/models/emnist/digits/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.digits.vgg import (
     VGG11,
     VGG11_BN,
@@ -47,7 +48,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",
@@ -64,7 +65,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="digits",

--- a/tests/models/emnist/letters/test_alexnet.py
+++ b/tests/models/emnist/letters/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.alexnet import AlexNet
 import torch
 
@@ -38,7 +39,7 @@ def emnist_single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -55,7 +56,7 @@ def emnist_3_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="byclass",
         download=True,

--- a/tests/models/emnist/letters/test_densenet.py
+++ b/tests/models/emnist/letters/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.densenet import (
     DenseNet121,
     DenseNet161,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",

--- a/tests/models/emnist/letters/test_lenet.py
+++ b/tests/models/emnist/letters/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.lenet import LeNet
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="letters",
         download=True,
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="letters",
         download=True,

--- a/tests/models/emnist/letters/test_mlp.py
+++ b/tests/models/emnist/letters/test_mlp.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.mlp import MLP
 import torch
 
@@ -35,7 +36,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -52,7 +53,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",

--- a/tests/models/emnist/letters/test_mobilenet.py
+++ b/tests/models/emnist/letters/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -42,7 +43,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -59,7 +60,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",

--- a/tests/models/emnist/letters/test_resnet.py
+++ b/tests/models/emnist/letters/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.resnet import (
     ResNet18,
     ResNet34,
@@ -48,7 +49,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -65,7 +66,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",

--- a/tests/models/emnist/letters/test_shufflenetv2.py
+++ b/tests/models/emnist/letters/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",

--- a/tests/models/emnist/letters/test_squeezenet.py
+++ b/tests/models/emnist/letters/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",

--- a/tests/models/emnist/letters/test_vgg.py
+++ b/tests/models/emnist/letters/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.letters.vgg import (
     VGG11,
     VGG11_BN,
@@ -47,7 +48,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -64,7 +65,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",

--- a/tests/models/emnist/mnist/test_alexnet.py
+++ b/tests/models/emnist/mnist/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.alexnet import AlexNet
 import torch
 
@@ -38,7 +39,7 @@ def emnist_single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",
@@ -55,7 +56,7 @@ def emnist_3_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="byclass",
         download=True,

--- a/tests/models/emnist/mnist/test_densenet.py
+++ b/tests/models/emnist/mnist/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.densenet import (
     DenseNet121,
     DenseNet161,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",

--- a/tests/models/emnist/mnist/test_lenet.py
+++ b/tests/models/emnist/mnist/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.lenet import LeNet
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="digits",
         download=True,
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         split="digits",
         download=True,

--- a/tests/models/emnist/mnist/test_mlp.py
+++ b/tests/models/emnist/mnist/test_mlp.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.mlp import MLP
 import torch
 
@@ -35,7 +36,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",
@@ -52,7 +53,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",

--- a/tests/models/emnist/mnist/test_mobilenet.py
+++ b/tests/models/emnist/mnist/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -42,7 +43,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",
@@ -59,7 +60,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="letters",

--- a/tests/models/emnist/mnist/test_resnet.py
+++ b/tests/models/emnist/mnist/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.resnet import (
     ResNet18,
     ResNet34,
@@ -48,7 +49,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",
@@ -65,7 +66,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",

--- a/tests/models/emnist/mnist/test_shufflenetv2.py
+++ b/tests/models/emnist/mnist/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -43,7 +44,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",
@@ -60,7 +61,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",

--- a/tests/models/emnist/mnist/test_squeezenet.py
+++ b/tests/models/emnist/mnist/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",
@@ -55,7 +56,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",

--- a/tests/models/emnist/mnist/test_vgg.py
+++ b/tests/models/emnist/mnist/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.emnist.mnist.vgg import (
     VGG11,
     VGG11_BN,
@@ -47,7 +48,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",
@@ -64,7 +65,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.EMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         split="mnist",

--- a/tests/models/fashionmnist/test_alexnet.py
+++ b/tests/models/fashionmnist/test_alexnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.alexnet import AlexNet
 import torch
 
@@ -38,7 +39,7 @@ def fashionmnist_single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -54,7 +55,7 @@ def fashionmnist_3_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/tests/models/fashionmnist/test_densenet.py
+++ b/tests/models/fashionmnist/test_densenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.densenet import (
     DenseNet121,
     DenseNet161,
@@ -43,7 +44,7 @@ def fashionmnist_single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -59,7 +60,7 @@ def fashionmnist_3_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/tests/models/fashionmnist/test_lenet.py
+++ b/tests/models/fashionmnist/test_lenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.lenet import LeNet
 import torch
 
@@ -38,7 +39,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -54,7 +55,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/tests/models/fashionmnist/test_mlp.py
+++ b/tests/models/fashionmnist/test_mlp.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.mlp import MLP
 import torch
 
@@ -35,7 +36,7 @@ def single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -51,7 +52,7 @@ def three_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/tests/models/fashionmnist/test_mobilenet.py
+++ b/tests/models/fashionmnist/test_mobilenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.mobilenet import (
     MobileNetV2,
     MobileNetV3Small,
@@ -42,7 +43,7 @@ def fashionmnist_single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -58,7 +59,7 @@ def fashionmnist_3_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/tests/models/fashionmnist/test_resnet.py
+++ b/tests/models/fashionmnist/test_resnet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.resnet import (
     ResNet18,
     ResNet34,
@@ -48,7 +49,7 @@ def fashionmnist_single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -64,7 +65,7 @@ def fashionmnist_3_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/tests/models/fashionmnist/test_shufflenetv2.py
+++ b/tests/models/fashionmnist/test_shufflenetv2.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.shufflenetv2 import (
     ShuffleNetv2_x0_5,
     ShuffleNetv2_x1_0,
@@ -43,7 +44,7 @@ def fashionmnist_single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -59,7 +60,7 @@ def fashionmnist_3_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/tests/models/fashionmnist/test_squeezenet.py
+++ b/tests/models/fashionmnist/test_squeezenet.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.squeezenet import SqueezeNet1_0, SqueezeNet1_1
 import torch
 
@@ -38,7 +39,7 @@ def fashionmnist_single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -54,7 +55,7 @@ def fashionmnist_3_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/tests/models/fashionmnist/test_vgg.py
+++ b/tests/models/fashionmnist/test_vgg.py
@@ -5,6 +5,7 @@
 import pytest
 from torchvision import datasets, transforms
 import os
+from torchfl.compatibility import TORCHFL_DIR
 from torchfl.models.core.fashionmnist.vgg import (
     VGG11,
     VGG11_BN,
@@ -47,7 +48,7 @@ def fashionmnist_single_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_single_channel"],
@@ -63,7 +64,7 @@ def fashionmnist_3_channel_loader():
     """
     global data_transforms
     return datasets.FashionMNIST(
-        root=os.path.join(os.pardir, "data"),
+        root=os.path.join(TORCHFL_DIR, "data"),
         train=True,
         download=True,
         transform=data_transforms["train_3_channels"],

--- a/torchfl/compatibility.py
+++ b/torchfl/compatibility.py
@@ -3,7 +3,8 @@
 # mypy: ignore-errors
 
 """Defines the constants to ensure the consistency and compatibility between the files."""
-from typing import Type, Literal, Dict, Any
+import enum
+from typing import Dict, Any
 from torch.optim import (
     Adadelta,
     Adagrad,
@@ -21,7 +22,7 @@ from torch.optim import (
 )
 from torch.nn import Tanh, ReLU, LeakyReLU, GELU
 
-# normal
+
 DATASETS = ["mnist", "emnist_digits", "cifar10"]
 OPTIMIZERS = [
     "adadelta",
@@ -40,44 +41,36 @@ OPTIMIZERS = [
 ]
 ACTIVATION_FUNCTIONS = ["tanh", "relu", "leakyrelu", "gelu"]
 
-# type literals
-DATASETS_LITERAL: Type[Literal["mnist", "emnist_digits", "cifar10"]] = Literal[
-    "mnist", "emnist_digits", "cifar10"
-]
-OPTIMIZERS_LITERAL: Type[
-    Literal[
-        "adadelta",
-        "adagrad",
-        "adam",
-        "adamw",
-        "sparseadam",
-        "adamax",
-        "asgd",
-        "lbfgs",
-        "nadam",
-        "radam",
-        "rmsprop",
-        "rprop",
-        "sgd",
-    ]
-] = Literal[
-    "adadelta",
-    "adagrad",
-    "adam",
-    "adamw",
-    "sparseadam",
-    "adamax",
-    "asgd",
-    "lbfgs",
-    "nadam",
-    "radam",
-    "rmsprop",
-    "rprop",
-    "sgd",
-]
-ACTIVATION_FUNCTIONS_LITERAL: Type[
-    Literal["tanh", "relu", "leakyrelu", "gelu"]
-] = Literal["tanh", "relu", "leakyrelu", "gelu"]
+
+class DATASETS_TYPE(enum.Enum):
+    MNIST = "mnist"
+    EMNIST_DIGITS = "emnist_digits"
+    CIFAR10 = "cifar10"
+
+
+class OPTIMIZERS_TYPE(enum.Enum):
+    ADAM = "adam"
+    ADAMW = "adamw"
+    ADAMAX = "adamax"
+    ADAGRAD = "adagrad"
+    ADADALTA = "adadelta"
+    ASGD = "asgd"
+    LBFGS = "lbfgs"
+    NADAM = "nadam"
+    RADAM = "radam"
+    RMSPROP = "rmsprop"
+    RPROP = "rprop"
+    SGD = "sgd"
+    SPARSEADAM = "sparseadam"
+
+
+class ACTIVATION_FUNCTIONS_TYPE(enum.Enum):
+    TANH = "tanh"
+    RELU = "relu"
+    LEAKYRELU = "leakyrelu"
+    GELU = "gelu"
+
+
 # mappings
 OPTIMIZERS_BY_NAME: Dict[str, Any] = {
     "adadelta": Adadelta,

--- a/torchfl/compatibility.py
+++ b/torchfl/compatibility.py
@@ -4,6 +4,8 @@
 
 """Defines the constants to ensure the consistency and compatibility between the files."""
 import enum
+import os
+from pathlib import Path
 from typing import Dict, Any
 from torch.optim import (
     Adadelta,
@@ -22,7 +24,7 @@ from torch.optim import (
 )
 from torch.nn import Tanh, ReLU, LeakyReLU, GELU
 
-
+TORCHFL_DIR: str = os.path.join(Path.home(), ".torchfl")
 DATASETS = ["mnist", "emnist_digits", "cifar10"]
 OPTIMIZERS = [
     "adadelta",
@@ -43,12 +45,16 @@ ACTIVATION_FUNCTIONS = ["tanh", "relu", "leakyrelu", "gelu"]
 
 
 class DATASETS_TYPE(enum.Enum):
+    """Enum class for the supported datasets."""
+
     MNIST = "mnist"
     EMNIST_DIGITS = "emnist_digits"
     CIFAR10 = "cifar10"
 
 
 class OPTIMIZERS_TYPE(enum.Enum):
+    """Enum class for the supported optimizers."""
+
     ADAM = "adam"
     ADAMW = "adamw"
     ADAMAX = "adamax"

--- a/torchfl/datamodules/cifar.py
+++ b/torchfl/datamodules/cifar.py
@@ -42,6 +42,8 @@ DEFAULT_TRANSFORMS: transforms.Compose = transforms.Compose(
 
 
 class SUPPORTED_DATASETS_TYPE(enum.Enum):
+    """Enum for supported datasets."""
+
     CIFAR10 = "cifar10"
     CIFAR100 = "cifar100"
 
@@ -131,7 +133,7 @@ class CIFARDataModule(pl.LightningDataModule):
         if not os.path.exists(TORCHFL_DIR):
             os.mkdir(TORCHFL_DIR)
         self.data_dir: str = data_dir
-        if dataset_name not in SUPPORTED_DATASETS:
+        if dataset_name.value not in SUPPORTED_DATASETS:
             raise ValueError(f"{dataset_name}: Not a supported dataset.")
         self.dataset_name: str = dataset_name.value
         self.train_transform: transforms.Compose = train_transforms

--- a/torchfl/datamodules/cifar.py
+++ b/torchfl/datamodules/cifar.py
@@ -10,11 +10,12 @@ Returns:
     - DatasetSplit: Implementation of PyTorch key-value based Dataset.
     - CIFARDataModule: PyTorch LightningDataModule for CIFAR datasets. Supports iid and non-iid splits.
 """
+import enum
 import torch
 import numpy as np
 from pathlib import Path
 import pytorch_lightning as pl
-from typing import Set, Type, Literal, Iterable, Tuple, Any, Optional, Dict, List
+from typing import Set, Iterable, Tuple, Any, Optional, Dict, List
 import os
 from torch.utils.data import random_split, DataLoader, Dataset
 from torchvision.datasets import CIFAR10, CIFAR100
@@ -29,11 +30,6 @@ pl.seed_everything(42)
 ###################
 TORCHFL_DIR: str = os.path.join(Path.home(), ".torchfl")
 SUPPORTED_DATASETS: Set[str] = {"cifar10", "cifar100"}
-SUPPORTED_DATASETS_LITERAL: Type[
-    Literal["cifar10", "cifar100"]
-] = Literal[  # type: ignore
-    "cifar10", "cifar100"
-]  # type: ignore
 
 DEFAULT_TRANSFORMS: transforms.Compose = transforms.Compose(
     [
@@ -44,6 +40,12 @@ DEFAULT_TRANSFORMS: transforms.Compose = transforms.Compose(
     ]
 )
 
+
+class SUPPORTED_DATASETS_TYPE(enum.Enum):
+    CIFAR10 = "cifar10"
+    CIFAR100 = "cifar100"
+
+
 #################
 # End Constants #
 #################
@@ -52,15 +54,16 @@ DEFAULT_TRANSFORMS: transforms.Compose = transforms.Compose(
 class DatasetSplit(Dataset):
     """Implementation of PyTorch key-value based Dataset."""
 
-    def __init__(self, dataset: Dataset, idxs: Iterable[int]) -> None:
+    def __init__(self, dataset: Any, idxs: Iterable[int]) -> None:
         """Constructor
 
         Args:
             - dataset (Dataset): PyTorch Dataset.
-            - idxs (Iterable[int]): collection of indices.
+            - idxs (List[int]): collection of indices.
         """
+        super().__init__()
         self.dataset: Dataset = dataset
-        self.idxs: Iterable[int] = list(idxs)
+        self.idxs: List[int] = list(idxs)
         all_targets: np.ndarray = (
             np.array(dataset.targets)
             if isinstance(dataset.targets, list)
@@ -74,7 +77,7 @@ class DatasetSplit(Dataset):
         Returns:
             - int: length of the collection of indices.
         """
-        return len(self.idxs)  # type: ignore
+        return len(self.idxs)
 
     def __getitem__(self, index: int) -> Tuple[Any, Any]:
         """Overriding the get method.
@@ -85,7 +88,7 @@ class DatasetSplit(Dataset):
         Returns:
             - Tuple[Any, Any]: returns the key-value pair as a tuple.
         """
-        image, label = self.dataset[self.idxs[index]]  # type: ignore
+        image, label = self.dataset[self.idxs[index]]
         return image, label
 
 
@@ -95,7 +98,7 @@ class CIFARDataModule(pl.LightningDataModule):
     def __init__(
         self,
         data_dir: str = os.path.join(TORCHFL_DIR, "data"),
-        dataset_name: SUPPORTED_DATASETS_LITERAL = "cifar10",  # type: ignore
+        dataset_name: SUPPORTED_DATASETS_TYPE = SUPPORTED_DATASETS_TYPE.CIFAR10,
         validation_split: float = 0.1,
         train_batch_size: int = 32,
         validation_batch_size: int = 32,
@@ -105,12 +108,12 @@ class CIFARDataModule(pl.LightningDataModule):
         val_transforms: transforms.Compose = DEFAULT_TRANSFORMS,
         test_transforms: transforms.Compose = DEFAULT_TRANSFORMS,
         predict_transforms: transforms.Compose = DEFAULT_TRANSFORMS,
-    ):  # type: ignore
+    ):
         """Constructor
 
         Args:
             - data_dir (str, optional): Default directory to download the dataset to. Defaults to os.pardir.
-            - dataset_name (SUPPORTED_DATASETS_LITERAL, optional): Name of the dataset to be used. Defaults to "cifar10".
+            - dataset_name (str, optional): Name of the dataset to be used. Defaults to "cifar10".
             - validation_split (float, optional): Fraction of training images to be used as validation. Defaults to 0.1.
             - train_batch_size (int, optional): Default batch size of the training data. Defaults to 32.
             - validation_batch_size (int, optional): Default batch size of the validation data. Defaults to 32.
@@ -130,7 +133,7 @@ class CIFARDataModule(pl.LightningDataModule):
         self.data_dir: str = data_dir
         if dataset_name not in SUPPORTED_DATASETS:
             raise ValueError(f"{dataset_name}: Not a supported dataset.")
-        self.dataset_name: str = dataset_name
+        self.dataset_name: str = dataset_name.value
         self.train_transform: transforms.Compose = train_transforms
         self.val_transform: transforms.Compose = val_transforms
         self.test_transform: transforms.Compose = test_transforms

--- a/torchfl/datamodules/emnist.py
+++ b/torchfl/datamodules/emnist.py
@@ -40,6 +40,8 @@ SUPPORTED_DATASETS: Set[str] = {
 
 
 class SUPPORTED_DATASETS_TYPE(enum.Enum):
+    """Enum for supported EMNIST datasets."""
+
     BALANCED = "balanced"
     BYCLASS = "byclass"
     BYMERGE = "bymerge"
@@ -139,7 +141,7 @@ class EMNISTDataModule(pl.LightningDataModule):
         if not os.path.exists(TORCHFL_DIR):
             os.mkdir(TORCHFL_DIR)
         self.data_dir: str = data_dir
-        if dataset_name not in SUPPORTED_DATASETS:
+        if dataset_name.value not in SUPPORTED_DATASETS:
             raise ValueError(f"{dataset_name}: Not a supported dataset.")
         self.dataset_name: str = dataset_name.value
         self.train_transform: transforms.Compose = train_transforms

--- a/torchfl/datamodules/fashionmnist.py
+++ b/torchfl/datamodules/fashionmnist.py
@@ -7,6 +7,7 @@ Returns:
     - DatasetSplit: Implementation of PyTorch key-value based Dataset.
     - FashionMNISTDataModule: PyTorch LightningDataModule for FashionMNIST datasets. Supports iid and non-iid splits.
 """
+import enum
 import torch
 import numpy as np
 from pathlib import Path
@@ -33,6 +34,14 @@ DEFAULT_TRANSFORMS: transforms.Compose = transforms.Compose(
         transforms.Normalize((0.1307,), (0.3081,)),
     ]
 )
+
+
+class SUPPORTED_DATASETS_TYPE(enum.Enum):
+    """Enum for supported FashionMNIST datasets."""
+
+    FASHIONMNIST = "FashionMNIST"
+
+
 #################
 # End Constants #
 #################
@@ -41,15 +50,15 @@ DEFAULT_TRANSFORMS: transforms.Compose = transforms.Compose(
 class DatasetSplit(Dataset):
     """Implementation of PyTorch key-value based Dataset."""
 
-    def __init__(self, dataset: Dataset, idxs: Iterable[int]) -> None:
+    def __init__(self, dataset: Any, idxs: Iterable[int]) -> None:
         """Constructor
 
         Args:
             - dataset (Dataset): PyTorch Dataset.
-            - idxs (Iterable[int]): collection of indices.
+            - idxs (List[int]): collection of indices.
         """
-        self.dataset: Dataset = dataset
-        self.idxs: Iterable[int] = list(idxs)
+        self.dataset: Any = dataset
+        self.idxs: List[int] = list(idxs)
         all_targets: np.ndarray = (
             np.array(dataset.targets)
             if isinstance(dataset.targets, list)
@@ -63,7 +72,7 @@ class DatasetSplit(Dataset):
         Returns:
             - int: length of the collection of indices.
         """
-        return len(self.idxs)  # type: ignore
+        return len(self.idxs)
 
     def __getitem__(self, index: int) -> Tuple[Any, Any]:
         """Overriding the get method.
@@ -74,7 +83,7 @@ class DatasetSplit(Dataset):
         Returns:
             - Tuple[Any, Any]: returns the key-value pair as a tuple.
         """
-        image, label = self.dataset[self.idxs[index]]  # type: ignore
+        image, label = self.dataset[self.idxs[index]]
         return image, label
 
 

--- a/torchfl/models/wrapper/cifar.py
+++ b/torchfl/models/wrapper/cifar.py
@@ -3,7 +3,8 @@
 
 """Contains the PyTorch Lightning wrapper modules for CIFAR10 and CIFAR100 dataset."""
 
-from typing import List, Optional, Type, Literal, Union, Dict, Any, Tuple
+import enum
+from typing import List, Optional, Type, Union, Dict, Any, Tuple
 from torchfl.models.core.cifar.cifar10.alexnet import AlexNet as CIFAR10AlexNet
 from torchfl.models.core.cifar.cifar10.densenet import (
     DenseNet121 as CIFAR10DenseNet121,
@@ -94,7 +95,7 @@ from torchfl.models.core.cifar.cifar100.vgg import (
 )
 import pytorch_lightning as pl
 import torch.nn as nn
-from torchfl.compatibility import OPTIMIZERS_LITERAL, OPTIMIZERS_BY_NAME
+from torchfl.compatibility import OPTIMIZERS_TYPE, OPTIMIZERS_BY_NAME
 from torch import Tensor, optim
 
 pl.seed_everything(42)
@@ -138,75 +139,41 @@ CIFAR_MODELS: List[str] = [
     "vgg19_bn",
 ]
 
-CIFAR_MODELS_LITERAL: Type[
-    Literal[
-        "alexnet",
-        "densenet121",
-        "densenet161",
-        "densenet169",
-        "densenet201",
-        "lenet",
-        "mobilenetv2",
-        "mobilenetv3small",
-        "mobilenetv3large",
-        "resnet18",
-        "resnet34",
-        "resnet50",
-        "resnet101",
-        "resnet152",
-        "resnext50_32x4d",
-        "resnext101_32x8d",
-        "wideresnet50_2",
-        "wideresnet101_2",
-        "shufflenetv2_x0_5",
-        "shufflenetv2_x1_0",
-        "shufflenetv2_x1_5",
-        "shufflenetv2_x2_0",
-        "squeezenet1_0",
-        "squeezenet1_1",
-        "vgg11",
-        "vgg11_bn",
-        "vgg13",
-        "vgg13_bn",
-        "vgg16",
-        "vgg16_bn",
-        "vgg19",
-        "vgg19_bn",
-    ]
-] = Literal[  # type: ignore
-    "alexnet",
-    "densenet121",
-    "densenet161",
-    "densenet169",
-    "densenet201",
-    "lenet",
-    "mobilenetv2",
-    "mobilenetv2small",
-    "mobilenetv3large",
-    "resnet18",
-    "resnet34",
-    "resnet50",
-    "resnet101",
-    "resnet152",
-    "resnext50_32x4d",
-    "resnext101_32x8d",
-    "wideresnet50_2",
-    "wideresnet101_2",
-    "shufflenetv2_x0_5",
-    "shufflenetv2_x1_0",
-    "shufflenetv2_x1_5",
-    "shufflenetv2_x2_0",
-    "squeezenet1_0",
-    "squeezenet1_1",
-    "vgg11",
-    "vgg11_bn",
-    "vgg13",
-    "vgg13_bn",
-    "vgg16",
-    "vgg16_bn",
-    "vgg19",
-    "vgg19_bn",
-]
+
+class CIFAR_MODELS_ENUM(enum.Enum):
+    ALEXNET = "alexnet"
+    DENSENET121 = "densenet121"
+    DENSENET161 = "densenet161"
+    DENSENET169 = "densenet169"
+    DENSENET201 = "densenet201"
+    LENET = "lenet"
+    MOBILENETV2 = "mobilenetv2"
+    MOBILENETV3SMALL = "mobilenetv3small"
+    MOBILENETV3LARGE = "mobilenetv3large"
+    RESNET18 = "resnet18"
+    RESNET34 = "resnet34"
+    RESNET50 = "resnet50"
+    RESNET101 = "resnet101"
+    RESNET152 = "resnet152"
+    RESNEXT50_32X4D = "resnext50_32x4d"
+    RESNEXT101_32X8D = "resnext101_32x8d"
+    WIDERESNET50_2 = "wideresnet50_2"
+    WIDERESNET101_2 = "wideresnet101_2"
+    SHUFFLENETV2_X0_5 = "shufflenetv2_x0_5"
+    SHUFFLENETV2_X1_0 = "shufflenetv2_x1_0"
+    SHUFFLENETV2_X1_5 = "shufflenetv2_x1_5"
+    SHUFFLENETV2_X2_0 = "shufflenetv2_x2_0"
+    SQUEEZENET1_0 = "squeezenet1_0"
+    SQUEEZENET1_1 = "squeezenet1_1"
+    VGG11 = "vgg11"
+    VGG11_BN = "vgg11_bn"
+    VGG13 = "vgg13"
+    VGG13_BN = "vgg13_bn"
+    VGG16 = "vgg16"
+    VGG16_BN = "vgg16_bn"
+    VGG19 = "vgg19"
+    VGG19_BN = "vgg19_bn"
+
 
 CIFAR10_MODEL_TYPE = Union[
     Type[CIFAR10AlexNet],
@@ -401,28 +368,30 @@ class CIFAR10(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: CIFAR_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: CIFAR_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (CIFAR_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
-            dataset_name="cifar10", model_name=model_name, model_hparams=model_hparams
+            dataset_name="cifar10",
+            model_name=model_name.value,
+            model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
                 "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }
@@ -512,28 +481,30 @@ class CIFAR100(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: CIFAR_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: CIFAR_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (CIFAR_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
-            dataset_name="cifar100", model_name=model_name, model_hparams=model_hparams
+            dataset_name="cifar100",
+            model_name=model_name.value,
+            model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
                 "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }

--- a/torchfl/models/wrapper/cifar.py
+++ b/torchfl/models/wrapper/cifar.py
@@ -141,6 +141,8 @@ CIFAR_MODELS: List[str] = [
 
 
 class CIFAR_MODELS_ENUM(enum.Enum):
+    """Enum for supported CIFAR models."""
+
     ALEXNET = "alexnet"
     DENSENET121 = "densenet121"
     DENSENET161 = "densenet161"

--- a/torchfl/models/wrapper/emnist.py
+++ b/torchfl/models/wrapper/emnist.py
@@ -323,6 +323,8 @@ EMNIST_MODELS: List[str] = [
 
 
 class EMNIST_MODELS_ENUM(enum.Enum):
+    """Enum for supported EMNIST models."""
+
     ALEXNET = "alexnet"
     DENSENET121 = "densenet121"
     DENSENET161 = "densenet161"

--- a/torchfl/models/wrapper/emnist.py
+++ b/torchfl/models/wrapper/emnist.py
@@ -3,7 +3,8 @@
 
 """Contains the PyTorch Lightning wrapper modules for all EMNIST datasets."""
 
-from typing import List, Optional, Type, Literal, Union, Dict, Any, Tuple
+import enum
+from typing import List, Optional, Type, Union, Dict, Any, Tuple
 from torchfl.models.core.emnist.balanced.alexnet import AlexNet as BalancedAlexNet
 from torchfl.models.core.emnist.balanced.densenet import (
     DenseNet121 as BalancedDenseNet121,
@@ -276,7 +277,7 @@ from torchfl.models.core.emnist.mnist.vgg import (
 )
 import pytorch_lightning as pl
 import torch.nn as nn
-from torchfl.compatibility import OPTIMIZERS_LITERAL, OPTIMIZERS_BY_NAME
+from torchfl.compatibility import OPTIMIZERS_TYPE, OPTIMIZERS_BY_NAME
 from torch import Tensor, optim
 
 pl.seed_everything(42)
@@ -320,77 +321,42 @@ EMNIST_MODELS: List[str] = [
     "vgg19_bn",
 ]
 
-EMNIST_MODELS_LITERAL: Type[
-    Literal[
-        "alexnet",
-        "densenet121",
-        "densenet161",
-        "densenet169",
-        "densenet201",
-        "lenet",
-        "mlp",
-        "mobilenetv2",
-        "mobilenetv3small",
-        "mobilenetv3large",
-        "resnet18",
-        "resnet34",
-        "resnet50",
-        "resnet101",
-        "resnet152",
-        "resnext50_32x4d",
-        "resnext101_32x8d",
-        "wideresnet50_2",
-        "wideresnet101_2",
-        "shufflenetv2_x0_5",
-        "shufflenetv2_x1_0",
-        "shufflenetv2_x1_5",
-        "shufflenetv2_x2_0",
-        "squeezenet1_0",
-        "squeezenet1_1",
-        "vgg11",
-        "vgg11_bn",
-        "vgg13",
-        "vgg13_bn",
-        "vgg16",
-        "vgg16_bn",
-        "vgg19",
-        "vgg19_bn",
-    ]
-] = Literal[  # type: ignore
-    "alexnet",
-    "densenet121",
-    "densenet161",
-    "densenet169",
-    "densenet201",
-    "lenet",
-    "mlp",
-    "mobilenetv2",
-    "mobilenetv2small",
-    "mobilenetv3large",
-    "resnet18",
-    "resnet34",
-    "resnet50",
-    "resnet101",
-    "resnet152",
-    "resnext50_32x4d",
-    "resnext101_32x8d",
-    "wideresnet50_2",
-    "wideresnet101_2",
-    "shufflenetv2_x0_5",
-    "shufflenetv2_x1_0",
-    "shufflenetv2_x1_5",
-    "shufflenetv2_x2_0",
-    "squeezenet1_0",
-    "squeezenet1_1",
-    "vgg11",
-    "vgg11_bn",
-    "vgg13",
-    "vgg13_bn",
-    "vgg16",
-    "vgg16_bn",
-    "vgg19",
-    "vgg19_bn",
-]
+
+class EMNIST_MODELS_ENUM(enum.Enum):
+    ALEXNET = "alexnet"
+    DENSENET121 = "densenet121"
+    DENSENET161 = "densenet161"
+    DENSENET169 = "densenet169"
+    DENSENET201 = "densenet201"
+    LENET = "lenet"
+    MLP = "mlp"
+    MOBILENETV2 = "mobilenetv2"
+    MOBILENETV3SMALL = "mobilenetv3small"
+    MOBILENETV3LARGE = "mobilenetv3large"
+    RESNET18 = "resnet18"
+    RESNET34 = "resnet34"
+    RESNET50 = "resnet50"
+    RESNET101 = "resnet101"
+    RESNET152 = "resnet152"
+    RESNEXT50_32X4D = "resnext50_32x4d"
+    RESNEXT101_32X8D = "resnext101_32x8d"
+    WIDERESNET50_2 = "wideresnet50_2"
+    WIDERESNET101_2 = "wideresnet101_2"
+    SHUFFLENETV2_X0_5 = "shufflenetv2_x0_5"
+    SHUFFLENETV2_X1_0 = "shufflenetv2_x1_0"
+    SHUFFLENETV2_X1_5 = "shufflenetv2_x1_5"
+    SHUFFLENETV2_X2_0 = "shufflenetv2_x2_0"
+    SQUEEZENET1_0 = "squeezenet1_0"
+    SQUEEZENET1_1 = "squeezenet1_1"
+    VGG11 = "vgg11"
+    VGG11_BN = "vgg11_bn"
+    VGG13 = "vgg13"
+    VGG13_BN = "vgg13_bn"
+    VGG16 = "vgg16"
+    VGG16_BN = "vgg16_bn"
+    VGG19 = "vgg19"
+    VGG19_BN = "vgg19_bn"
+
 
 EMNIST_BALANCED_MODEL_TYPE = Union[
     Type[BalancedAlexNet],
@@ -923,28 +889,30 @@ class BalancedEMNIST(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: EMNIST_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: EMNIST_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (EMNIST_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
-            dataset_name="balanced", model_name=model_name, model_hparams=model_hparams
+            dataset_name="balanced",
+            model_name=model_name.value,
+            model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
-                "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_name": optimizer_name.value,
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }
@@ -1034,28 +1002,30 @@ class ByClassEMNIST(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: EMNIST_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: EMNIST_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (EMNIST_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
-            dataset_name="byclass", model_name=model_name, model_hparams=model_hparams
+            dataset_name="byclass",
+            model_name=model_name.value,
+            model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
                 "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }
@@ -1145,28 +1115,30 @@ class ByMergeEMNIST(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: EMNIST_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: EMNIST_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (EMNIST_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
-            dataset_name="bymerge", model_name=model_name, model_hparams=model_hparams
+            dataset_name="bymerge",
+            model_name=model_name.value,
+            model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
                 "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }
@@ -1256,28 +1228,30 @@ class LettersEMNIST(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: EMNIST_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: EMNIST_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (EMNIST_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
-            dataset_name="letters", model_name=model_name, model_hparams=model_hparams
+            dataset_name="letters",
+            model_name=model_name.value,
+            model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
                 "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }
@@ -1367,28 +1341,30 @@ class DigitsEMNIST(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: EMNIST_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: EMNIST_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (EMNIST_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
-            dataset_name="digits", model_name=model_name, model_hparams=model_hparams
+            dataset_name="digits",
+            model_name=model_name.value,
+            model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
                 "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }
@@ -1478,28 +1454,30 @@ class MNISTEMNIST(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: EMNIST_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: EMNIST_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (EMNIST_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
-            dataset_name="mnist", model_name=model_name, model_hparams=model_hparams
+            dataset_name="mnist",
+            model_name=model_name.value,
+            model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
                 "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }

--- a/torchfl/models/wrapper/fashionmnist.py
+++ b/torchfl/models/wrapper/fashionmnist.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """Contains the PyTorch Lightning wrapper module for FashionMNIST dataset."""
-
-from typing import List, Optional, Type, Literal, Union, Dict, Any, Tuple
+import enum
+from typing import List, Optional, Union, Dict, Any, Tuple, Type
 from torchfl.models.core.fashionmnist.alexnet import AlexNet as FashionMNISTAlexNet
 from torchfl.models.core.fashionmnist.densenet import (
     DenseNet121 as FashionMNISTDenseNet121,
@@ -52,7 +52,7 @@ from torchfl.models.core.fashionmnist.vgg import (
 
 import pytorch_lightning as pl
 import torch.nn as nn
-from torchfl.compatibility import OPTIMIZERS_LITERAL, OPTIMIZERS_BY_NAME
+from torchfl.compatibility import OPTIMIZERS_TYPE, OPTIMIZERS_BY_NAME
 from torch import Tensor, optim
 
 pl.seed_everything(42)
@@ -97,77 +97,42 @@ FASHIONMNIST_MODELS: List[str] = [
     "vgg19_bn",
 ]
 
-FASHIONMNIST_MODELS_LITERAL: Type[
-    Literal[
-        "alexnet",
-        "densenet121",
-        "densenet161",
-        "densenet169",
-        "densenet201",
-        "lenet",
-        "mlp",
-        "mobilenetv2",
-        "mobilenetv3small",
-        "mobilenetv3large",
-        "resnet18",
-        "resnet34",
-        "resnet50",
-        "resnet101",
-        "resnet152",
-        "resnext50_32x4d",
-        "resnext101_32x8d",
-        "wideresnet50_2",
-        "wideresnet101_2",
-        "shufflenetv2_x0_5",
-        "shufflenetv2_x1_0",
-        "shufflenetv2_x1_5",
-        "shufflenetv2_x2_0",
-        "squeezenet1_0",
-        "squeezenet1_1",
-        "vgg11",
-        "vgg11_bn",
-        "vgg13",
-        "vgg13_bn",
-        "vgg16",
-        "vgg16_bn",
-        "vgg19",
-        "vgg19_bn",
-    ]
-] = Literal[  # type: ignore
-    "alexnet",
-    "densenet121",
-    "densenet161",
-    "densenet169",
-    "densenet201",
-    "lenet",
-    "mlp",
-    "mobilenetv2",
-    "mobilenetv2small",
-    "mobilenetv3large",
-    "resnet18",
-    "resnet34",
-    "resnet50",
-    "resnet101",
-    "resnet152",
-    "resnext50_32x4d",
-    "resnext101_32x8d",
-    "wideresnet50_2",
-    "wideresnet101_2",
-    "shufflenetv2_x0_5",
-    "shufflenetv2_x1_0",
-    "shufflenetv2_x1_5",
-    "shufflenetv2_x2_0",
-    "squeezenet1_0",
-    "squeezenet1_1",
-    "vgg11",
-    "vgg11_bn",
-    "vgg13",
-    "vgg13_bn",
-    "vgg16",
-    "vgg16_bn",
-    "vgg19",
-    "vgg19_bn",
-]
+
+class FASHIONMNIST_MODELS_ENUM(enum.Enum):
+    ALEXNET = "alexnet"
+    DENSENET121 = "densenet121"
+    DENSENET161 = "densenet161"
+    DENSENET169 = "densenet169"
+    DENSENET201 = "densenet201"
+    LENET = "lenet"
+    MLP = "mlp"
+    MOBILENETV2 = "mobilenetv2"
+    MOBILENETV3SMALL = "mobilenetv3small"
+    MOBILENETV3LARGE = "mobilenetv3large"
+    RESNET18 = "resnet18"
+    RESNET34 = "resnet34"
+    RESNET50 = "resnet50"
+    RESNET101 = "resnet101"
+    RESNET152 = "resnet152"
+    RESNEXT50_32X4D = "resnext50_32x4d"
+    RESNEXT101_32X8D = "resnext101_32x8d"
+    WIDERESNET50_2 = "wideresnet50_2"
+    WIDERESNET101_2 = "wideresnet101_2"
+    SHUFFLENETV2_X0_5 = "shufflenetv2_x0_5"
+    SHUFFLENETV2_X1_0 = "shufflenetv2_x1_0"
+    SHUFFLENETV2_X1_5 = "shufflenetv2_x1_5"
+    SHUFFLENETV2_X2_0 = "shufflenetv2_x2_0"
+    SQUEEZENET1_0 = "squeezenet1_0"
+    SQUEEZENET1_1 = "squeezenet1_1"
+    VGG11 = "vgg11"
+    VGG11_BN = "vgg11_bn"
+    VGG13 = "vgg13"
+    VGG13_BN = "vgg13_bn"
+    VGG16 = "vgg16"
+    VGG16_BN = "vgg16_bn"
+    VGG19 = "vgg19"
+    VGG19_BN = "vgg19_bn"
+
 
 FASHIONMNIST_MODEL_TYPE = Union[
     Type[FashionMNISTAlexNet],
@@ -284,30 +249,30 @@ class FashionMNIST(pl.LightningModule):
 
     def __init__(
         self,
-        model_name: FASHIONMNIST_MODELS_LITERAL,  # type: ignore
-        optimizer_name: OPTIMIZERS_LITERAL,  # type: ignore
+        model_name: FASHIONMNIST_MODELS_ENUM,
+        optimizer_name: OPTIMIZERS_TYPE,
         optimizer_hparams: Dict[str, Any],
         model_hparams: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Default constructor.
 
         Args:
-            - model_name (FASHUONMNIST_MODELS_LITERAL): Name of the model to be used. Only choose from the available models.
-            - optimizer_name (OPTIMIZERS_LITERAL): Name of optimizer to be used. Only choose from the available models.
+            - model_name (str): Name of the model to be used. Only choose from the available models.
+            - optimizer_name (str): Name of optimizer to be used. Only choose from the available models.
             - optimizer_hparams(Dict[str, Any]): Hyperparameters to initialize the optimizer.
             - model_hparams (Optional[Dict[str, Any]], optional): Optional override the default model hparams. Defaults to None.
         """
         super().__init__()
         self.model = create_model(
             dataset_name="fashionmnist",
-            model_name=model_name,
+            model_name=model_name.value,
             model_hparams=model_hparams,
         )
         combined_hparams: Dict[str, Any] = {
             "model_hparams": vars(self.model.hparams),
             "optimizer_hparams": {
                 "optimizer_name": optimizer_name,
-                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name],
+                "optimizer_fn": OPTIMIZERS_BY_NAME[optimizer_name.value],
                 "config": optimizer_hparams,
             },
         }

--- a/torchfl/models/wrapper/fashionmnist.py
+++ b/torchfl/models/wrapper/fashionmnist.py
@@ -99,6 +99,8 @@ FASHIONMNIST_MODELS: List[str] = [
 
 
 class FASHIONMNIST_MODELS_ENUM(enum.Enum):
+    """Enum for supported FashionMNIST models."""
+
     ALEXNET = "alexnet"
     DENSENET121 = "densenet121"
     DENSENET161 = "densenet161"


### PR DESCRIPTION
## Acceptance Criteria (AC)
- [x] Added more workflows to build the ```torchfl``` package on different os and python versions before merging it to master.
- [x] Updated the existing workfows to include the checks for all python versions to ensure backwards compatibility.
- [x] Removed the usage of ```Literal``` type to enable py36, py37 support.
- [x] Defined a common cache in home dir for torchfl which will be used to store the files instead of the parent dir.   